### PR TITLE
check validity condition for schema object attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 /.idea
 /*.iml
+.DS_Store

--- a/src/clj_annotations/validation.clj
+++ b/src/clj_annotations/validation.clj
@@ -110,8 +110,10 @@
       ;; Type checks
       (= (type typ) ::core/schema)
       (let [obj-result (validate-object path typ obj opts)]
-        ;; if there were no errors in the object, check the validity condition
-        (if (not-any? #(= (:level %) :error) obj-result)
+        ;; if there were no errors in the object, check the validity condition,
+        ;; unless it was already checked at the vector level
+        (if (and (not (:multi-valued schema))
+                 (not-any? #(= (:level %) :error) obj-result))
           (concat obj-result (eval-validity-condition path schema obj opts))
           obj-result))
 
@@ -124,6 +126,9 @@
       ;; Validation
       (and canon-vals (not-any? (set canon-vals) [obj]))
       (make-result schema obj path :canonical-value-mismatch nil)
+
+      (:multi-valued schema)
+      [] ; already checked at the vector level
 
       :else
       (eval-validity-condition path schema obj opts))))

--- a/src/clj_annotations/validation.clj
+++ b/src/clj_annotations/validation.clj
@@ -108,8 +108,12 @@
                             (f schema obj))]
     (cond
       ;; Type checks
-      (and (= (type typ) ::core/schema))
-      (validate-object path typ obj opts)
+      (= (type typ) ::core/schema)
+      (let [obj-result (validate-object path typ obj opts)]
+        ;; if there were no errors in the object, check the validity condition
+        (if (not-any? #(= (:level %) :error) obj-result)
+          (concat obj-result (eval-validity-condition path schema obj opts))
+          obj-result))
 
       (and (contains? type-checks typ) type-check-result)
       (make-result schema obj path :type-mismatch type-check-result)

--- a/src/clj_annotations/validation.clj
+++ b/src/clj_annotations/validation.clj
@@ -136,11 +136,12 @@
 (defn- validate-vector-attribute
   [path schema obj {:keys [make-result validation-fns] :as opts}]
   (if (sequential? obj)
-    (let [vec-result (eval-validity-condition path schema obj opts)
-          validate   (fn [i v]
-                       (validate-scalar-attribute (conj path i) schema v opts))
-          elem-results (apply concat (map-indexed validate obj))]
-      (concat vec-result elem-results))
+    (let [validate (fn [i v]
+                     (validate-scalar-attribute (conj path i) schema v opts))
+          elem-results (apply concat (map-indexed validate obj))
+          vec-result (when (empty? elem-results)
+                       (eval-validity-condition path schema obj opts))]
+      (concat elem-results vec-result))
     (make-result schema obj path :non-array-value nil)))
 
 (defn- validate-attribute

--- a/test/clj_annotations/validation_test.clj
+++ b/test/clj_annotations/validation_test.clj
@@ -257,21 +257,29 @@
                :message "Duplicate values"}]
              (sut/validate-object player (assoc base-player :emails bad-emails))))))
 
-  (testing "validation of complex multi-valued attributes"
-    (is (= [{:path    "/websites"
-             :level   :error
-             :kind    :validation-failure
-             :message "Collection length should be less than or equal to 2"}
-            {:path    "/websites/2/location"
+  (testing "multi-valued validity is not checked unless all elements are valid"
+    (is (= [{:path    "/websites/2/location"
              :level   :error
              :kind    :type-mismatch
              :message "Malformed URL"}]
-          (sut/validate-object player {:id        "c2a5080c-d09b-49c7-baa9-38602235c9c5"
-                                       :name      "Raghu"
-                                       :verified? true
-                                       :websites  [{:location "http://www.google.com"}
-                                                   {:location "http://www.github.com"}
-                                                   {:location ""}]}))))
+           (sut/validate-object player {:id        "c2a5080c-d09b-49c7-baa9-38602235c9c5"
+                                        :name      "Raghu"
+                                        :verified? true
+                                        :websites  [{:location "http://www.google.com"}
+                                                    {:location "http://www.github.com"}
+                                                    {:location ""}]}))))
+
+  (testing "multi-valued validity is checked if all elements are valid"
+    (is (= [{:path    "/websites"
+             :level   :error
+             :kind    :validation-failure
+             :message "Collection length should be less than or equal to 2"}]
+           (sut/validate-object player {:id        "c2a5080c-d09b-49c7-baa9-38602235c9c5"
+                                        :name      "Raghu"
+                                        :verified? true
+                                        :websites  [{:location "http://www.google.com"}
+                                                    {:location "http://www.github.com"}
+                                                    {:location "http://www.clojure.org"}]}))))
 
   (testing "uniqueness on multi-valued attributes"
     (is (= [{:path    "/websites"


### PR DESCRIPTION
Currently, `:validity` conditions are ignored for attributes of type `::core/schema` (#17).  This PR fixes that.  The validity condition is only checked if the object being checked had no other validation errors.

It also fixes a bug where the `:validity` condition on a multi-valued attribute would be called once at the level of the whole attribute (vector), but then be called again on each individual item within the vector. This PR removes the latter calls, so now the validity function will only be called at the vector level.